### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and analyze

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read


### PR DESCRIPTION
Potential fix for [https://github.com/rrusson/Grammar.Net/security/code-scanning/3](https://github.com/rrusson/Grammar.Net/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root in `.github/workflows/build.yml` so all jobs inherit least-privilege token scopes unless overridden.  
For this workflow, the best minimal fix is:

- `permissions:`
  - `contents: read`

This does not change existing functionality (checkout and normal read operations continue to work) and satisfies the CodeQL requirement to explicitly limit `GITHUB_TOKEN` permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
